### PR TITLE
Feature/todo3 persistence validation

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,25 +1,24 @@
-// eslint.config.js
-import js from '@eslint/js';
-import globals from 'globals';
+import js from "@eslint/js";
+import globals from "globals";
 
 export default [
-  { ignores: ['node_modules', 'coverage', 'dist'] },
+  { ignores: ["node_modules", "coverage", "dist"] },
 
   js.configs.recommended,
   {
-    files: ['**/*.js'],
+    files: ["**/*.js"],
     languageOptions: {
-      ecmaVersion: 'latest',
-      sourceType: 'module',
+      ecmaVersion: "latest",
+      sourceType: "module",
       globals: {
         ...globals.browser,
         ...globals.node,
-        ...globals.jest
-      }
+        ...globals.jest,
+      },
     },
     rules: {
-      'no-unused-vars': ['warn', { argsIgnorePattern: '^_' }],
-      'no-console': 'off'
-    }
-  }
+      "no-unused-vars": ["warn", { argsIgnorePattern: "^_" }],
+      "no-console": "off",
+    },
+  },
 ];

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,24 +1,54 @@
+// eslint.config.js (Flat config, ESM)
 import js from "@eslint/js";
 import globals from "globals";
+import noUnsanitized from "eslint-plugin-no-unsanitized";
 
 export default [
+  // Global ignores
   { ignores: ["node_modules", "coverage", "dist"] },
 
   js.configs.recommended,
+
   {
     files: ["**/*.js"],
     languageOptions: {
       ecmaVersion: "latest",
       sourceType: "module",
-      globals: {
-        ...globals.browser,
-        ...globals.node,
-        ...globals.jest,
-      },
+      globals: { ...globals.browser },
     },
+    plugins: { "no-unsanitized": noUnsanitized },
     rules: {
+      "no-unsanitized/method": "error",
+      "no-unsanitized/property": "error",
       "no-unused-vars": ["warn", { argsIgnorePattern: "^_" }],
       "no-console": "off",
+    },
+  },
+
+  {
+    files: ["eslint.config.js", "**/*.config.js", "**/scripts/**/*.js"],
+    languageOptions: {
+      ecmaVersion: "latest",
+      sourceType: "module",
+      globals: { ...globals.node },
+    },
+  },
+
+  {
+    files: ["**/*.cjs"],
+    languageOptions: {
+      ecmaVersion: "latest",
+      sourceType: "commonjs",
+      globals: { ...globals.node },
+    },
+  },
+
+  {
+    files: ["**/*.{test,spec}.{js,cjs,mjs}"],
+    languageOptions: {
+      ecmaVersion: "latest",
+      sourceType: "commonjs",
+      globals: { ...globals.jest, ...globals.node },
     },
   },
 ];

--- a/mini-projects/js-mini-app/app.js
+++ b/mini-projects/js-mini-app/app.js
@@ -3,20 +3,10 @@ const input = document.getElementById("task-input");
 const ul = document.getElementById("task-list");
 const statusEl = document.getElementById("status");
 
-let idCounter = 0;
-
 form.addEventListener("submit", (event) => {
   event.preventDefault();
   const taskText = input.value.trim();
   if (!taskText) return;
-
-  // const li = document.createElement("li");
-  // li.textContent = taskText;
-  // ul.appendChild(li);
-
-  // statusEl.textContent = `Task “${taskText}” added.`;
-  // input.value = "";
-  // input.focus();
 
   ul.appendChild(createItem(taskText));
   announce(`Task “${taskText}” added.`);
@@ -27,12 +17,17 @@ form.addEventListener("submit", (event) => {
 function createItem(text) {
   const li = document.createElement("li");
 
+  const uid =
+    typeof crypto !== "undefined" && typeof crypto.randomUUID === "function"
+      ? crypto.randomUUID()
+      : `task-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
+
   const cb = document.createElement("input");
   cb.type = "checkbox";
-  cb.id = `task-${++idCounter}`;
+  cb.id = uid;
 
   const label = document.createElement("label");
-  label.htmlFor = cb.id;
+  label.htmlFor = uid;
   label.textContent = text;
 
   cb.addEventListener("change", () => {
@@ -45,7 +40,9 @@ function createItem(text) {
   const del = document.createElement("button");
   del.type = "button";
   del.className = "delete-btn";
-  del.innerHTML = `Delete <span class="sr-only">task “${text}”</span>`;
+  del.textContent = "Delete";
+  del.setAttribute("aria-label", `Delete task "${text}"`);
+
   del.addEventListener("click", () => {
     li.remove();
     announce(`Task “${text}” deleted.`);
@@ -57,5 +54,8 @@ function createItem(text) {
 }
 
 function announce(message) {
-  statusEl.textContent = message;
+  statusEl.textContent = "";
+  setTimeout(() => {
+    statusEl.textContent = message;
+  }, 0);
 }

--- a/mini-projects/js-mini-app/app.js
+++ b/mini-projects/js-mini-app/app.js
@@ -3,16 +3,59 @@ const input = document.getElementById("task-input");
 const ul = document.getElementById("task-list");
 const statusEl = document.getElementById("status");
 
+let idCounter = 0;
+
 form.addEventListener("submit", (event) => {
   event.preventDefault();
   const taskText = input.value.trim();
   if (!taskText) return;
 
-  const li = document.createElement("li");
-  li.textContent = taskText;
-  ul.appendChild(li);
+  // const li = document.createElement("li");
+  // li.textContent = taskText;
+  // ul.appendChild(li);
 
-  statusEl.textContent = `Task “${taskText}” added.`;
+  // statusEl.textContent = `Task “${taskText}” added.`;
+  // input.value = "";
+  // input.focus();
+
+  ul.appendChild(createItem(taskText));
+  announce(`Task “${taskText}” added.`);
   input.value = "";
   input.focus();
 });
+
+function createItem(text) {
+  const li = document.createElement("li");
+
+  const cb = document.createElement("input");
+  cb.type = "checkbox";
+  cb.id = `task-${++idCounter}`;
+
+  const label = document.createElement("label");
+  label.htmlFor = cb.id;
+  label.textContent = text;
+
+  cb.addEventListener("change", () => {
+    li.classList.toggle("completed", cb.checked);
+    announce(
+      `Task “${text}” ${cb.checked ? "completed" : "marked as not completed"}.`
+    );
+  });
+
+  const del = document.createElement("button");
+  del.type = "button";
+  del.className = "delete-btn";
+  del.innerHTML = `Delete <span class="sr-only">task “${text}”</span>`;
+  del.addEventListener("click", () => {
+    li.remove();
+    announce(`Task “${text}” deleted.`);
+    input.focus();
+  });
+
+  li.append(cb, label, del);
+  return li;
+}
+
+function announce(message) {
+  statusEl.textContent = message;
+}

--- a/mini-projects/js-mini-app/app.js
+++ b/mini-projects/js-mini-app/app.js
@@ -2,38 +2,63 @@ const form = document.getElementById("form");
 const input = document.getElementById("task-input");
 const ul = document.getElementById("task-list");
 const statusEl = document.getElementById("status");
+const errorEl = document.getElementById("form-error");
+
+const STORAGE_KEY = "todo.tasks.v1";
+
+let tasks = loadTasks();
+renderAll(tasks);
 
 form.addEventListener("submit", (event) => {
+  if (errorEl.textContent) clearError();
   event.preventDefault();
-  const taskText = input.value.trim();
-  if (!taskText) return;
+  const raw = input.value;
+  const text = normalizeText(raw);
+  if (!text) {
+    showError("Please enter a task.");
+    return;
+  }
+  if (isDuplicate(text, tasks)) {
+    showError("This task already exists.");
+    return;
+  }
+  clearError();
+  input.removeAttribute("aria-invalid");
 
-  ul.appendChild(createItem(taskText));
-  announce(`Task “${taskText}” added.`);
+  const id = genId();
+  const task = { id, text, completed: false };
+
+  tasks = [...tasks, task];
+  saveTasks(tasks);
+
+  ul.appendChild(createItem(task));
+  announce(`Task “${text}” added.`);
   input.value = "";
   input.focus();
 });
 
-function createItem(text) {
+function createItem(task) {
   const li = document.createElement("li");
-
-  const uid =
-    typeof crypto !== "undefined" && typeof crypto.randomUUID === "function"
-      ? crypto.randomUUID()
-      : `task-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
 
   const cb = document.createElement("input");
   cb.type = "checkbox";
-  cb.id = uid;
+  cb.id = task.id;
+  cb.checked = !!task.completed;
 
   const label = document.createElement("label");
-  label.htmlFor = uid;
-  label.textContent = text;
+  label.htmlFor = task.id;
+  label.textContent = task.text;
 
   cb.addEventListener("change", () => {
     li.classList.toggle("completed", cb.checked);
+    tasks = tasks.map((t) =>
+      t.id === task.id ? { ...t, completed: cb.checked } : t
+    );
+    saveTasks(tasks);
     announce(
-      `Task “${text}” ${cb.checked ? "completed" : "marked as not completed"}.`
+      `Task “${task.text}” ${
+        cb.checked ? "completed" : "marked as not completed"
+      }.`
     );
   });
 
@@ -41,21 +66,73 @@ function createItem(text) {
   del.type = "button";
   del.className = "delete-btn";
   del.textContent = "Delete";
-  del.setAttribute("aria-label", `Delete task "${text}"`);
+  del.setAttribute("aria-label", `Delete task "${task.text}"`);
 
   del.addEventListener("click", () => {
     li.remove();
-    announce(`Task “${text}” deleted.`);
+    tasks = tasks.filter((t) => t.id !== task.id);
+    saveTasks(tasks);
+    announce(`Task “${task.text}” deleted.`);
     input.focus();
   });
 
+  li.classList.toggle("completed", !!task.completed);
   li.append(cb, label, del);
   return li;
+}
+
+function renderAll(list) {
+  ul.replaceChildren(...list.map(createItem));
+}
+
+function loadTasks() {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    return raw ? JSON.parse(raw) : [];
+  } catch {
+    return [];
+  }
+}
+
+function saveTasks(list) {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(list));
+  } catch {
+    announce("Saving failed. Check storage permissions or quota.");
+  }
 }
 
 function announce(message) {
   statusEl.textContent = "";
   setTimeout(() => {
     statusEl.textContent = message;
-  }, 0);
+  }, 1000);
+}
+
+function normalizeText(text) {
+  return text.trim().replace(/\s+/g, " ");
+}
+
+function isDuplicate(text, list) {
+  return list.some((t) => t.text.toLowerCase() === text.toLowerCase());
+}
+
+function genId() {
+  if (
+    typeof crypto !== "undefined" &&
+    typeof crypto.randomUUID === "function"
+  ) {
+    return crypto.randomUUID();
+  }
+  return `task-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
+}
+
+function showError(msg) {
+  input.setAttribute("aria-invalid", "true");
+  errorEl.textContent = msg;
+}
+
+function clearError() {
+  input.removeAttribute("aria-invalid");
+  errorEl.textContent = "";
 }

--- a/mini-projects/js-mini-app/app.logic.cjs
+++ b/mini-projects/js-mini-app/app.logic.cjs
@@ -1,0 +1,11 @@
+function normalizeText(text) {
+  return text.trim().replace(/\s+/g, " ");
+}
+
+function addTask(list, rawText, id = "id-1") {
+  const text = normalizeText(rawText);
+  if (!text) return list;
+  return [...list, { id, text, completed: false }];
+}
+
+module.exports = { addTask, normalizeText };

--- a/mini-projects/js-mini-app/app.logic.test.cjs
+++ b/mini-projects/js-mini-app/app.logic.test.cjs
@@ -1,0 +1,18 @@
+const { addTask, normalizeText } = require("./app.logic.cjs");
+
+test("normalizeText trims and collapses spaces", () => {
+  expect(normalizeText("  Hello  world  ")).toBe("Hello world");
+});
+
+test("addTask adds a task with normalized text and completed=false", () => {
+  const prev = [];
+  const next = addTask(prev, "  Buy  milk  ");
+  expect(next).toHaveLength(1);
+  expect(next[0]).toMatchObject({ text: "Buy milk", completed: false });
+});
+
+test("addTask ignores empty input", () => {
+  const prev = [{ id: "x", text: "Existing", completed: false }];
+  const next = addTask(prev, "  ");
+  expect(next).toEqual(prev);
+});

--- a/mini-projects/js-mini-app/index.html
+++ b/mini-projects/js-mini-app/index.html
@@ -17,8 +17,15 @@
           type="text"
           placeholder="Enter a new task"
           required
-          aria-describedby="task-hint"
+          aria-describedby="task-hint form-error"
+          maxlength="120"
         />
+        <p
+          id="form-error"
+          class="form-error"
+          role="alert"
+          aria-live="assertive"
+        ></p>
         <div id="task-hint" class="sr-only">
           Type a task and press Add Task.
         </div>

--- a/mini-projects/js-mini-app/index.html
+++ b/mini-projects/js-mini-app/index.html
@@ -11,7 +11,7 @@
       <h1>Todo</h1>
 
       <form id="form" autocomplete="off">
-        <label for="task-input">New task</label>
+        <label for="task-input" class="sr-only">New task</label>
         <input
           id="task-input"
           type="text"

--- a/mini-projects/js-mini-app/index.html
+++ b/mini-projects/js-mini-app/index.html
@@ -36,6 +36,6 @@
       ></div>
     </main>
 
-    <script type="module" src="app.js"></script>
+    <script src="app.js"></script>
   </body>
 </html>

--- a/mini-projects/js-mini-app/style.css
+++ b/mini-projects/js-mini-app/style.css
@@ -55,11 +55,6 @@ form {
   align-items: flex-end;
 }
 
-form label {
-  position: absolute;
-  left: -9999px;
-}
-
 #task-input {
   flex: 1;
   padding: 8px;
@@ -86,6 +81,11 @@ li label {
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
+}
+
+li.completed label {
+  color: #6b7280;
+  text-decoration: line-through;
 }
 
 li .delete-btn {

--- a/mini-projects/js-mini-app/style.css
+++ b/mini-projects/js-mini-app/style.css
@@ -10,7 +10,8 @@ body {
 body {
   margin: 0;
   padding: 24px;
-  font-family: system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial, "Noto Sans", "Liberation Sans", sans-serif;
+  font-family: system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue",
+    Arial, "Noto Sans", "Liberation Sans", sans-serif;
   line-height: 1.5;
 }
 
@@ -37,7 +38,7 @@ body {
   background: #fff;
   padding: 24px;
   border-radius: 12px;
-  box-shadow: 0 10px 30px rgba(0, 0, 0, .06);
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.06);
 }
 
 h1 {
@@ -59,7 +60,7 @@ form label {
   left: -9999px;
 }
 
-input {
+#task-input {
   flex: 1;
   padding: 8px;
 }
@@ -71,9 +72,22 @@ ul {
 }
 
 li {
-  padding: 10px 12px;
-  margin-bottom: 10px;
-  border: 1px solid #f3f4f6;
-  border-radius: 10px;
-  background: #fff;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+li input[type="checkbox"] {
+  margin: 0;
+}
+
+li label {
+  flex: 1;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+li .delete-btn {
+  margin-left: auto;
 }

--- a/mini-projects/js-mini-app/style.css
+++ b/mini-projects/js-mini-app/style.css
@@ -91,3 +91,38 @@ li.completed label {
 li .delete-btn {
   margin-left: auto;
 }
+
+.form-error {
+  margin: 6px 0 0;
+  color: #b91c1c;
+  font-size: 0.9rem;
+  min-height: 1.2em;
+}
+#task-input[aria-invalid="true"] {
+  border: 1px solid #fca5a5;
+  box-shadow: 0 0 0 3px rgba(239, 68, 68, 0.15);
+}
+
+@media (max-width: 520px) {
+  form {
+    flex-direction: column;
+    align-items: stretch;
+  }
+  #task-input {
+    width: 100%;
+  }
+  #button {
+    width: 100%;
+    min-height: 44px;
+  }
+}
+
+#task-input,
+button,
+input[type="checkbox"] {
+  min-height: 44px;
+}
+li input[type="checkbox"] {
+  width: 1.1rem;
+  height: 1.1rem;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "eslint": "^9.34.0",
         "globals": "^16.3.0",
         "jest": "^30.1.3",
+        "open-cli": "^8.0.0",
         "typescript": "^5.9.2"
       }
     },
@@ -2078,6 +2079,13 @@
         "tslib": "^2.8.0"
       }
     },
+    "node_modules/@tokenizer/token": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
+      "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.0.tgz",
@@ -2720,6 +2728,19 @@
         "win32"
       ]
     },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -2931,6 +2952,27 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/brace-expansion": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
@@ -2997,12 +3039,53 @@
         "node-int64": "^0.4.0"
       }
     },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/bundle-name": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+      "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "run-applescript": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/callsites": {
       "version": "3.1.0",
@@ -3270,6 +3353,35 @@
         "node": ">= 8"
       }
     },
+    "node_modules/crypto-random-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-4.0.0.tgz",
+      "integrity": "sha512-x8dy3RnvYdlUcPOjkEHqozhiwzKNSq7GcPuXFbnyMOCHxX8V3OgIg/pYuabl2sbUPfIJaeAQB7PMOK8DFIdoRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/crypto-random-string/node_modules/type-fest": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
+      "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
@@ -3318,6 +3430,49 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/default-browser": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.2.1.tgz",
+      "integrity": "sha512-WY/3TUME0x3KPYdRRxEJJvXRHV4PyPoUsxtZa78lwItwRQRHhd2U9xOscaT/YTf8uCXIAjeJOFBVEh/7FtD8Xg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bundle-name": "^4.1.0",
+        "default-browser-id": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser-id": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.0.tgz",
+      "integrity": "sha512-A6p/pu/6fyBcA1TRz/GqWYPViplrftcW2gZC9q79ngNCKAeR/X3gcEdXQHl4KNXV+3wgIJ1CPkJQ3IHM6lcsyA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/define-lazy-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/detect-libc": {
@@ -3643,6 +3798,26 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
     "node_modules/execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -3786,6 +3961,24 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/file-type": {
+      "version": "18.7.0",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-18.7.0.tgz",
+      "integrity": "sha512-ihHtXRzXEziMrQ56VSgU7wkxh55iNchFkosu7Y9/S+tXHdKyrGjVK0ujbqNnsxzea+78MaLhN6PGmfYSAv1ACw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readable-web-to-node-stream": "^3.0.2",
+        "strtok3": "^7.0.0",
+        "token-types": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/file-type?sponsor=1"
+      }
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -3906,6 +4099,19 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/get-stdin": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-9.0.0.tgz",
+      "integrity": "sha512-dVKBjfWisLAicarI2Sf+JuBE/DghV4UzNAVe9yhEJuzeREd3JhOTE9cUaJTeSa77fsbQUK3pcOpJfM59+VKZaA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/get-stream": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
@@ -4007,6 +4213,27 @@
         "node": ">=10.17.0"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/ignore": {
       "version": "7.0.5",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
@@ -4090,6 +4317,22 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -4133,6 +4376,25 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-inside-container": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^3.0.0"
+      },
+      "bin": {
+        "is-inside-container": "cli.js"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -4151,6 +4413,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-wsl": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.0.tgz",
+      "integrity": "sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-inside-container": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -5017,6 +5295,19 @@
         "tmpl": "1.0.5"
       }
     },
+    "node_modules/meow": {
+      "version": "12.1.1",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-12.1.1.tgz",
+      "integrity": "sha512-BhXM0Au22RwUneMPwSCnyhTOizdWoIEPU9sp0Aqa1PnDMR5Wv2FGXYDjuzJEIX+Eo2Rb8xuYe5jrnm5QowQFkw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -5247,6 +5538,48 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/open": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
+      "integrity": "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "default-browser": "^5.2.1",
+        "define-lazy-prop": "^3.0.0",
+        "is-inside-container": "^1.0.0",
+        "wsl-utils": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/open-cli": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/open-cli/-/open-cli-8.0.0.tgz",
+      "integrity": "sha512-3muD3BbfLyzl+aMVSEfn2FfOqGdPYR0O4KNnxXsLEPE2q9OSjBfJAaB6XKbrUzLgymoSMejvb5jpXJfru/Ko2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "file-type": "^18.7.0",
+        "get-stdin": "^9.0.0",
+        "meow": "^12.1.1",
+        "open": "^10.0.0",
+        "tempy": "^3.1.0"
+      },
+      "bin": {
+        "open-cli": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -5399,6 +5732,20 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/peek-readable": {
+      "version": "5.4.2",
+      "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-5.4.2.tgz",
+      "integrity": "sha512-peBp3qZyuS6cNIJ2akRNG1uo1WJ1d0wTxg/fxMdZ0BqCVhx242bSFHM9eNqflfJVS9SsgkzgT/1UgnsurBOTMg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -5564,6 +5911,16 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -5640,6 +5997,40 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/readable-web-to-node-stream": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.4.tgz",
+      "integrity": "sha512-9nX56alTf5bwXQ3ZDipHJhusu9NTQJ/CVPtb/XHAJCXihZeitfJvIRS4GqQ/mfIoOE3IelHMrpayVrosdHBuLw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "^4.7.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -5694,6 +6085,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/run-applescript": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.0.0.tgz",
+      "integrity": "sha512-9by4Ij99JUr/MCFBUkDKLWK3G9HVXmabKz9U5MlIAIuvuzkiOicRYs8XJLxX+xahD+mLiiCYDqF9dKAgtzKP1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -5717,6 +6121,27 @@
       "dependencies": {
         "queue-microtask": "^1.2.2"
       }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/scheduler": {
       "version": "0.26.0",
@@ -5896,6 +6321,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "node_modules/string-length": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
@@ -6070,6 +6505,24 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strtok3": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-7.1.1.tgz",
+      "integrity": "sha512-mKX8HA/cdBqMKUr0MMZAFssCkIGoZeSCMXgnt79yKxNFguMLVFgRe6wB+fsL0NmoHDbeyZXczy7vEPSoo3rkzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/token": "^0.3.0",
+        "peek-readable": "^5.1.3"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
     "node_modules/styled-jsx": {
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
@@ -6120,6 +6573,61 @@
       },
       "funding": {
         "url": "https://opencollective.com/synckit"
+      }
+    },
+    "node_modules/temp-dir": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-3.0.0.tgz",
+      "integrity": "sha512-nHc6S/bwIilKHNRgK/3jlhDoIHcp45YgyiwcAk46Tr0LfEqGBVpmiAyuiuxeVE44m3mXnEeVhaipLOEWmH+Njw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      }
+    },
+    "node_modules/tempy": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tempy/-/tempy-3.1.0.tgz",
+      "integrity": "sha512-7jDLIdD2Zp0bDe5r3D2qtkd1QOCacylBuL7oa4udvN6v2pqr4+LcCr67C8DR1zkpaZ8XosF5m1yQSabKAW6f2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-stream": "^3.0.0",
+        "temp-dir": "^3.0.0",
+        "type-fest": "^2.12.2",
+        "unique-string": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/tempy/node_modules/is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/tempy/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/test-exclude": {
@@ -6203,6 +6711,24 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/token-types": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/token-types/-/token-types-5.0.1.tgz",
+      "integrity": "sha512-Y2fmSnZjQdDb9W4w4r1tswlMHylzWIeOKpx0aZH9BgGtACHhrk3OkT52AzwcuqTRBZtvvnTjDBh8eynMulu8Vg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/token": "^0.3.0",
+        "ieee754": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
     "node_modules/ts-api-utils": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
@@ -6278,6 +6804,22 @@
       "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/unique-string": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-3.0.0.tgz",
+      "integrity": "sha512-VGXBUVwxKMBUznyffQweQABPRRW1vHZAbadFZud4pLFAqRGvv/96vafgjWFqzourzr8YonlQiPgH0YCJfawoGQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "crypto-random-string": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/unrs-resolver": {
       "version": "1.11.1",
@@ -6520,6 +7062,22 @@
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/wsl-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
+      "integrity": "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-wsl": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/y18n": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@typescript-eslint/eslint-plugin": "^8.41.0",
         "@typescript-eslint/parser": "^8.41.0",
         "eslint": "^9.34.0",
+        "eslint-plugin-no-unsanitized": "^4.1.2",
         "globals": "^16.3.0",
         "jest": "^30.1.3",
         "open-cli": "^8.0.0",
@@ -3628,6 +3629,16 @@
         "jiti": {
           "optional": true
         }
+      }
+    },
+    "node_modules/eslint-plugin-no-unsanitized": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-no-unsanitized/-/eslint-plugin-no-unsanitized-4.1.2.tgz",
+      "integrity": "sha512-ydF3PMFKEIkP71ZbLHFvu6/FW8SvRv6VV/gECfrQkqyD5+5oCAtPz8ZHy0GRuMDtNe2jsNdPCQXX4LSbkapAVQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "peerDependencies": {
+        "eslint": "^8 || ^9"
       }
     },
     "node_modules/eslint-scope": {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "eslint": "^9.34.0",
     "globals": "^16.3.0",
     "jest": "^30.1.3",
+    "open-cli": "^8.0.0",
     "typescript": "^5.9.2"
   },
   "dependencies": {
@@ -15,9 +16,9 @@
   },
   "scripts": {
     "lint": "eslint .",
-    "dev": "xdg-open mini-projects/js-mini-app/index.html",
+    "dev": "open-cli mini-projects/js-mini-app/index.html",
     "build": "echo \"No build step for vanilla JS app\"",
-    "start": "xdg-open mini-projects/js-mini-app/index.html",
+    "start": "open-cli mini-projects/js-mini-app/index.html",
     "lint:fix": "eslint . --fix",
     "test": "jest",
     "test:e2e": "playwright test"

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "@typescript-eslint/eslint-plugin": "^8.41.0",
     "@typescript-eslint/parser": "^8.41.0",
     "eslint": "^9.34.0",
+    "eslint-plugin-no-unsanitized": "^4.1.2",
     "globals": "^16.3.0",
     "jest": "^30.1.3",
     "open-cli": "^8.0.0",


### PR DESCRIPTION
# Pull Request
Summary

Add Day 3 features on top of Task 2: persistence with localStorage, input validation (empty/duplicates), a small responsive tweak, and a focused unit test for pure logic.

Changes

Persistence:
Load existing tasks from localStorage on init (STORAGE_KEY = "todo.tasks.v1").
Save on add / toggle complete / delete.

Validation:
Normalize input (trim + collapse whitespace).
Block empty values and case-insensitive duplicates.
Set aria-invalid="true" and show an inline error (role="alert") for failures; clear error on input.

A11y:
<label for> ↔ checkbox id linkage.
aria-label on Delete → “Delete task "<name>””.
Live updates announced via a discreet role="status" region (announce() flush + async set).

Responsive layout:
Mobile stack (button below input) while preserving desktop layout.

Unit tests:
app.logic.cjs + app.logic.test.cjs for normalizeText and addTask behavior (normalization, add happy-path, ignore empty).

